### PR TITLE
feat: Throw error if test fails

### DIFF
--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -36,7 +36,7 @@ run: firmware.out
 	./firmware.out $(TEST_LOG) > $(EMUL_LOG)
 	@tail -n +6 $(TEST_VECTOR_RSP) > $(VALIDATION_LOG)
 	@sed -i 's/\r//' $(VALIDATION_LOG) #remove carriage return chars
-	@if cmp --silent $(VALIDATION_LOG) $(EMUL_LOG); then echo "\n\nShortMessage Test PASSED\n\n"; else echo "\n\nShortMessage Test FAILED\n\n"; fi;
+	@if cmp --silent $(VALIDATION_LOG) $(EMUL_LOG); then echo "\n\nShortMessage Test PASSED\n\n"; else echo "\n\nShortMessage Test FAILED\n\n"; exit 1; fi;
 	@rm -rf $(VALIDATION_LOG)
 
 build: firmware.out


### PR DESCRIPTION
Exit non 0 helps Jenkins catch Failed tests