### PR TITLE
fix(CI): increase fpga-build timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
   system-synthesis:
     runs-on: self-hosted
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- increase time to run fpga-build test from 30 to 60 mins