### PR TITLE
Mceliece FPGA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,31 +75,31 @@ jobs:
       - name: simulation clean
         run: make test-sim-clean ALGORITHM=AES256
 
-  AES-fusesoc-sim:
-    runs-on: self-hosted
-    timeout-minutes: 25
+  # AES-fusesoc-sim:
+  #   runs-on: self-hosted
+  #   timeout-minutes: 25
+  #
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: FuseSoC Simulation
+  #       run: make fusesoc-sim-run ALGORITHM=AES256
+  #     - name: FuseSoC clean
+  #       run: make fusesoc-clean
 
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - name: FuseSoC Simulation
-        run: make fusesoc-sim-run ALGORITHM=AES256
-      - name: FuseSoC clean
-        run: make fusesoc-clean
-
-  AES-fusesoc-fpga:
-    runs-on: self-hosted
-    timeout-minutes: 75
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: 'recursive'
-      - name: FuseSoC FPGA Test
-        run: make fusesoc-fpga-run ALGORITHM=AES256
-      - name: FuseSoC clean
-        run: make -C fusesoc clean-all
+  # AES-fusesoc-fpga:
+  #   runs-on: self-hosted
+  #   timeout-minutes: 75
+  #
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: FuseSoC FPGA Test
+  #       run: make fusesoc-fpga-run ALGORITHM=AES256
+  #     - name: FuseSoC clean
+  #       run: make -C fusesoc clean-all
 
   MCELIECE-pc-emul:
     runs-on: self-hosted
@@ -126,3 +126,16 @@ jobs:
         run: make test-sim ALGORITHM=MCELIECE
       - name: simulation clean
         run: make test-sim-clean ALGORITHM=MCELIECE
+
+  MCELIECE-fpga:
+    runs-on: self-hosted
+    timeout-minutes: 75
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: FPGA test
+        run: make test-fpga ALGORITHM=MCELIECE
+      - name: FPGA clean
+        run: make test-fpga-clean ALGORITHM=MCELIECE

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -27,7 +27,7 @@ SOC_OUT_BIN:=soc-out.bin
 ETH_LOG=ethernet.log
 
 # Board grad / release commands
-GRAB_CMD=board_client.py grab 180
+GRAB_CMD=board_client.py grab 600
 RELEASE_CMD=board_client.py release
 
 #RULES

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -43,7 +43,7 @@ ifeq ($(NORUN),0)
 ifeq ($(BOARD_SERVER),)
 	cp $(FIRM_DIR)/firmware.bin .
 	bash -c "trap '$(RELEASE_CMD)' INT TERM KILL; $(GRAB_CMD); ../prog.sh; $(CONSOLE_CMD) $(TEST_LOG); $(RELEASE_CMD);"
-	cp $(PYTHON_DIR)/$(SOC_OUT_BIN) .
+	cp $(SW_DIR)/python/$(SOC_OUT_BIN) .
 else
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude-from=$(ROOT_DIR)/.rsync_exclude $(ROOT_DIR) $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)
@@ -130,7 +130,7 @@ clean-all: hw-clean
 	@rm -rf $(FPGA_VERSAT_OBJ) $(FPGA_VERSAT_LOG)
 	@make -C $(SW_TEST_DIR) clean
 ifneq ($(FPGA_SERVER),)
-	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
+	ssh $(FPGA_USER)@$(FPGA_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude-from=$(ROOT_DIR)/.rsync_exclude $(ROOT_DIR) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)
 	ssh $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean CLEANIP=$(CLEANIP)'
 endif

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -43,6 +43,7 @@ ifeq ($(NORUN),0)
 ifeq ($(BOARD_SERVER),)
 	cp $(FIRM_DIR)/firmware.bin .
 	bash -c "trap '$(RELEASE_CMD)' INT TERM KILL; $(GRAB_CMD); ../prog.sh; $(CONSOLE_CMD) $(TEST_LOG); $(RELEASE_CMD);"
+	cp $(PYTHON_DIR)/$(SOC_OUT_BIN) .
 else
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude-from=$(ROOT_DIR)/.rsync_exclude $(ROOT_DIR) $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)
@@ -50,7 +51,7 @@ else
 ifneq ($(TEST_LOG),)
 	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD)/test.log .
 endif
-	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)/software/python/$(SOC_OUT_BIN) .
+	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD)/$(SOC_OUT_BIN) .
 	scp $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD)/ethernet.log .
 endif
 endif

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -125,19 +125,23 @@ test-validate:
 # Clean
 #
 
-clean-all: hw-clean
+clean-all: clean-local clean-remote
+
+clean-local: hw-clean
 	@rm -f $(FPGA_OBJ) $(FPGA_LOG) $(SOC_LOG) $(ETH_LOG)
 	@rm -rf $(FPGA_VERSAT_OBJ) $(FPGA_VERSAT_LOG)
 	@make -C $(SW_TEST_DIR) clean
+
+clean-remote:
 ifneq ($(FPGA_SERVER),)
 	ssh $(FPGA_USER)@$(FPGA_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude-from=$(ROOT_DIR)/.rsync_exclude $(ROOT_DIR) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)
-	ssh $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean CLEANIP=$(CLEANIP)'
+	ssh $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean-local CLEANIP=$(CLEANIP)'
 endif
 ifneq ($(BOARD_SERVER),)
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude-from=$(ROOT_DIR)/.rsync_exclude $(ROOT_DIR) $(BOARD_USER)@$(BOARD_SERVER):$(REMOTE_ROOT_DIR)
-	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean'
+	ssh $(BOARD_USER)@$(BOARD_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean-local'
 endif
 
 #clean test log only when board testing begins
@@ -167,4 +171,4 @@ debug:
 .PHONY: run build \
 	release \
 	test test-shortmsg run-shortmsg test-validate \
-	clean-all clean-testlog
+	clean-all clean-testlog clean-local clean-remote

--- a/software/firmware/MCELIECE/common/nistkatrng.c
+++ b/software/firmware/MCELIECE/common/nistkatrng.c
@@ -6,7 +6,6 @@
 //  Modified for liboqs by Douglas Stebila
 //
 
-#include <assert.h>
 #include <string.h>
 
 #include "aes.h"
@@ -36,7 +35,6 @@ static void AES256_ECB(uint8_t *key, uint8_t *ctr, uint8_t *buffer) {
 void nist_kat_init(uint8_t *entropy_input, const uint8_t *personalization_string, int security_strength) {
     uint8_t seed_material[48];
 
-    assert(security_strength == 256);
     memcpy(seed_material, entropy_input, 48);
     if (personalization_string) {
         for (int i = 0; i < 48; i++) {

--- a/software/firmware/MCELIECE/controlbits.c
+++ b/software/firmware/MCELIECE/controlbits.c
@@ -182,13 +182,13 @@ static void controlbitsfrompermutation(int w, int n, int step, int off, unsigned
 
     printf("\t\tcontrobitsfromperm %d\n", w);
 
-    uint32_t *ip = (uint32_t*) MemPool_Alloc(N*sizeof(uint32_t));
-    uint32_t *I = (uint32_t*) MemPool_Alloc(2*N*sizeof(uint32_t));
-    uint32_t *P_ = (uint32_t*) MemPool_Alloc(2*N*sizeof(uint32_t));
-    uint32_t *PI = (uint32_t*) MemPool_Alloc(2*N*sizeof(uint32_t));
-    uint32_t *T = (uint32_t*) MemPool_Alloc(2*N*sizeof(uint32_t));
-    uint32_t *piflip = (uint32_t*) MemPool_Alloc(N*sizeof(uint32_t));
-    uint32_t *subpi = (uint32_t*) MemPool_Alloc(2*(N/2)*sizeof(uint32_t));
+    uint32_t *ip = (uint32_t*) MemPool_Calloc(N*sizeof(uint32_t));
+    uint32_t *I = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));
+    uint32_t *P_ = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));
+    uint32_t *PI = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));
+    uint32_t *T = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));
+    uint32_t *piflip = (uint32_t*) MemPool_Calloc(N*sizeof(uint32_t));
+    uint32_t *subpi = (uint32_t*) MemPool_Calloc(2*(N/2)*sizeof(uint32_t));
 
     if (w == 1) {
         c[ off / 8 ] |= (pi[0] & 1) << (off % 8);
@@ -277,16 +277,13 @@ static void controlbitsfrompermutation(int w, int n, int step, int off, unsigned
 /* output: out, control bits w.r.t. pi */
 void PQCLEAN_MCELIECE348864_CLEAN_controlbits(unsigned char *out, const uint32_t *pi) {
     unsigned int i;
-    unsigned char *c = (unsigned char*) MemPool_Alloc( \
+    unsigned char *c = (unsigned char*) MemPool_Calloc( \
             ((2 * GFBITS - 1) * (1 << GFBITS) / 16 ) *(sizeof(unsigned char)));
-
-    for (i = 0; i < sizeof(c); i++) {
-        c[i] = 0;
-    }
+    int size_c = (2 * GFBITS - 1) * (1 << GFBITS) / 16;
 
     controlbitsfrompermutation(GFBITS, (1 << GFBITS), 1, 0, c, pi);
 
-    for (i = 0; i < sizeof(c); i++) {
+    for (i = 0; i < size_c; i++) {
         out[i] = c[i];
     }
     MemPool_Free(((2*GFBITS-1)*(1<<GFBITS)/16)*(sizeof(unsigned char))); // c

--- a/software/firmware/MCELIECE/controlbits.c
+++ b/software/firmware/MCELIECE/controlbits.c
@@ -180,8 +180,6 @@ static void controlbitsfrompermutation(int w, int n, int step, int off, unsigned
     int k;
     int t;
 
-    printf("\t\tcontrobitsfromperm %d\n", w);
-
     uint32_t *ip = (uint32_t*) MemPool_Calloc(N*sizeof(uint32_t));
     uint32_t *I = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));
     uint32_t *P_ = (uint32_t*) MemPool_Calloc(2*N*sizeof(uint32_t));

--- a/software/firmware/MCELIECE/controlbits.h
+++ b/software/firmware/MCELIECE/controlbits.h
@@ -7,6 +7,12 @@
 
 
 #include <stdint.h>
+#include "memory_pool.h"
+#ifndef PC
+#include "printf.h"
+#else
+#include <stdio.h>
+#endif
 
 void PQCLEAN_MCELIECE348864_CLEAN_sort_63b(int n, uint64_t *x);
 void PQCLEAN_MCELIECE348864_CLEAN_controlbits(unsigned char *out, const uint32_t *pi);

--- a/software/firmware/MCELIECE/fullMCELIECETests.cpp
+++ b/software/firmware/MCELIECE/fullMCELIECETests.cpp
@@ -149,7 +149,6 @@ void Full_McEliece_Test(Versat* versat) {
     MemPool_Alloc(dout_size);
     MemPool_Alloc(PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_SECRETKEYBYTES*sizeof(uint8_t));
     MemPool_Alloc(PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_PUBLICKEYBYTES*sizeof(uint8_t));
-    MemPool_Report("program end");
     MemPool_Destroy();
     return;
 }

--- a/software/firmware/MCELIECE/fullMCELIECETests.cpp
+++ b/software/firmware/MCELIECE/fullMCELIECETests.cpp
@@ -66,7 +66,7 @@ int save_msg(uint8_t *ptr, uint8_t* msg, int size){
 void Full_McEliece_Test(Versat* versat) {
     printf("Init Full McEliece Test\n");
     uint8_t *seed = NULL;
-    MemPool_Create(MEMORY_POOL_SIZE);
+    MemPool_Create(MEMORY_POOL_SIZE, MAX_NUM_SEEDS*SEED_BYTES);
     uint8_t *public_key = (uint8_t*) MemPool_Alloc( \
             PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_PUBLICKEYBYTES*sizeof(uint8_t));
     uint8_t *secret_key = (uint8_t*) MemPool_Alloc( \
@@ -80,8 +80,7 @@ void Full_McEliece_Test(Versat* versat) {
 #ifndef RUN_EXTMEM
     char *ddr_mem = (char*) (EXTRA_BASE);
 #else
-    char *ddr_mem = (char*) (secret_key + \
-            PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_SECRETKEYBYTES);
+    char *ddr_mem = (char*) (1 << (FIRM_ADDR_W));
 #endif
 #endif
     // Init ethernet
@@ -111,7 +110,8 @@ void Full_McEliece_Test(Versat* versat) {
     dout_size = num_seeds*(PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_PUBLICKEYBYTES+ \
             PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_SECRETKEYBYTES);
     // Output file starts after input file
-    dout_fp = din_fp + din_size;
+    // dout_fp = din_fp + din_size;
+    dout_fp = (uint8_t*) MemPool_Alloc(dout_size);
 
     // Message test loop
     int i=0;
@@ -146,6 +146,9 @@ void Full_McEliece_Test(Versat* versat) {
     eth_send_variable_file((char *) dout_fp, dout_size);
 #endif
     
+    MemPool_Alloc(dout_size);
+    MemPool_Alloc(PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_SECRETKEYBYTES*sizeof(uint8_t));
+    MemPool_Alloc(PQCLEAN_MCELIECE348864_CLEAN_CRYPTO_PUBLICKEYBYTES*sizeof(uint8_t));
     MemPool_Report("program end");
     MemPool_Destroy();
     return;

--- a/software/firmware/MCELIECE/fullMCELIECETests.hpp
+++ b/software/firmware/MCELIECE/fullMCELIECETests.hpp
@@ -19,6 +19,7 @@ extern "C"{
 #include "versatMCELIECE.hpp"
 
 #define SEED_BYTES (48)
+#define MAX_NUM_SEEDS (10)
 #define MEMORY_POOL_SIZE (10000000)
 
 int get_int(char* ptr, unsigned int *i_val);

--- a/software/firmware/MCELIECE/memory_pool.c
+++ b/software/firmware/MCELIECE/memory_pool.c
@@ -20,7 +20,9 @@ void MemPool_Create(int pool_size) {
 
 void MemPool_Destroy(void) {
   if (pool.pool_ptr != NULL) {
+#ifdef PC
     free(pool.pool_ptr);
+#endif
     pool.pool_ptr = NULL;
     pool.free_ptr = NULL;
     pool.pool_size = 0;

--- a/software/firmware/MCELIECE/memory_pool.c
+++ b/software/firmware/MCELIECE/memory_pool.c
@@ -2,12 +2,12 @@
 
 static MemoryPool pool;
 
-void MemPool_Create(int pool_size) {
+void MemPool_Create(int pool_size, int offset) {
   if (pool_size > 0) {
 #ifdef PC
     pool.pool_ptr = (uint8_t *)malloc(pool_size * sizeof(uint8_t));
 #else
-    pool.pool_ptr = (uint8_t *) (1 << (FIRM_ADDR_W));
+    pool.pool_ptr = (uint8_t *) ((1 << (FIRM_ADDR_W))+offset);
 #endif
     if (pool.pool_ptr != NULL) {
       pool.pool_size = pool_size;

--- a/software/firmware/MCELIECE/memory_pool.c
+++ b/software/firmware/MCELIECE/memory_pool.c
@@ -43,6 +43,16 @@ void *MemPool_Alloc(int alloc_size) {
   return (void*) alloc_ptr;
 }
 
+void *MemPool_Calloc(int alloc_size) {
+    // allocate memory
+    uint8_t* alloc_ptr = MemPool_Alloc(alloc_size);
+    // set memory to zero
+    for (int i = 0; i < alloc_size; i++) {
+        alloc_ptr[i] = 0;
+    }
+    return (void*) alloc_ptr;
+}
+
 void MemPool_Free(int free_size) {
   if (free_size < (pool.free_ptr - pool.pool_ptr)) {
     pool.free_ptr -= free_size;

--- a/software/firmware/MCELIECE/memory_pool.h
+++ b/software/firmware/MCELIECE/memory_pool.h
@@ -19,6 +19,7 @@ typedef struct MemoryPool_ MemoryPool;
 void MemPool_Create(int pool_size, int offset);
 void MemPool_Destroy(void);
 void *MemPool_Alloc(int alloc_size);
+void *MemPool_Calloc(int alloc_size);
 void MemPool_Free(int free_size);
 void MemPool_Report(char *rpt_str);
 

--- a/software/firmware/MCELIECE/memory_pool.h
+++ b/software/firmware/MCELIECE/memory_pool.h
@@ -1,8 +1,12 @@
 #ifndef H_MEMORY_POOL_H
 #define H_MEMORY_POOL_H
 #include <stdint.h>
+#ifdef PC
 #include <stdio.h>
 #include <stdlib.h>
+#else
+#include "printf.h"
+#endif
 
 struct MemoryPool_ {
   uint8_t *pool_ptr;

--- a/software/firmware/MCELIECE/memory_pool.h
+++ b/software/firmware/MCELIECE/memory_pool.h
@@ -16,7 +16,7 @@ struct MemoryPool_ {
 };
 typedef struct MemoryPool_ MemoryPool;
 
-void MemPool_Create(int pool_size);
+void MemPool_Create(int pool_size, int offset);
 void MemPool_Destroy(void);
 void *MemPool_Alloc(int alloc_size);
 void MemPool_Free(int free_size);

--- a/software/firmware/MCELIECE/operations.cpp
+++ b/software/firmware/MCELIECE/operations.cpp
@@ -128,7 +128,7 @@ int PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
     gf *irr = (gf*) MemPool_Alloc(SYS_T*sizeof(gf));
     uint32_t *perm = (uint32_t*) MemPool_Alloc((1 << GFBITS)*sizeof(uint32_t));
 
-    printf("\trandombytes\n");
+    printf("\n\trandombytes\n");
     randombytes(seed, 32*sizeof(uint8_t));
 
     while (1) {
@@ -137,7 +137,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
         PQCLEAN_MCELIECE348864_CLEAN_aes256ctr(r, sizeof_r, nonce, seed);
         memcpy(seed, &r[ sizeof_r - 32 ], 32);
 
-        printf("\tload2\n");
         for (i = 0; i < SYS_T; i++) {
             f[i] = PQCLEAN_MCELIECE348864_CLEAN_load2(rp + i * 2);
         }
@@ -147,7 +146,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
             continue;
         }
 
-        printf("\tload4\n");
         for (i = 0; i < (1 << GFBITS); i++) {
             perm[i] = PQCLEAN_MCELIECE348864_CLEAN_load4(rp + i * 4);
         }
@@ -157,7 +155,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
             continue;
         }
 
-        printf("\tstore2\n");
         for (i = 0; i < SYS_T;   i++) {
             PQCLEAN_MCELIECE348864_CLEAN_store2(sk + SYS_N / 8 + i * 2, irr[i]);
         }
@@ -173,7 +170,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_crypto_kem_keypair
         break;
     }
 
-    printf("\tOperations MemPool_Free()\n");
     MemPool_Free((1 << GFBITS)*sizeof(uint32_t)); // perm
     MemPool_Free(SYS_T*sizeof(gf)); // irr
     MemPool_Free(SYS_T*sizeof(gf)); // f

--- a/software/firmware/MCELIECE/versat_pk_gen.cpp
+++ b/software/firmware/MCELIECE/versat_pk_gen.cpp
@@ -27,7 +27,6 @@ static int n_systematic = 0;
 /* this function only mocks public key generation */
 int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8_t *sk) {
     int i, j, c;
-    printf("sim pk_gen\n");
     
     // this should never happen
     if (perm != NULL) {
@@ -92,29 +91,24 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         buf[i] |= i;
     }
 
-    printf("\t\tsort\n");
     PQCLEAN_MCELIECE348864_CLEAN_sort_63b(1 << GFBITS, buf);
 
     for (i = 0; i < (1 << GFBITS); i++) {
         perm[i] = buf[i] & GFMASK;
     }
 
-    printf("\t\tbitrev\n");
     for (i = 0; i < SYS_N;         i++) {
         L[i] = PQCLEAN_MCELIECE348864_CLEAN_bitrev((gf)perm[i]);
     }
 
     // filling the matrix
 
-    printf("\t\troot\n");
     PQCLEAN_MCELIECE348864_CLEAN_root(inv, g, L);
 
-    printf("\t\tgf_inv\n");
     for (i = 0; i < SYS_N; i++) {
         inv[i] = PQCLEAN_MCELIECE348864_CLEAN_gf_inv(inv[i]);
     }
 
-    printf("\t\tmat = 0\n");
     for (i = 0; i < PK_NROWS; i++) {
         for (j = 0; j < SYS_N / 8; j++) {
             // mat[i][j] = 0;
@@ -122,7 +116,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         }
     }
 
-    printf("\t\tinv:\n");
     for (i = 0; i < SYS_T; i++) {
         for (j = 0; j < SYS_N; j += 8) {
             for (k = 0; k < GFBITS;  k++) {
@@ -149,7 +142,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         for (j = 0; j < SYS_N; j++) {
             inv[j] = PQCLEAN_MCELIECE348864_CLEAN_gf_mul(inv[j], L[j]);
         }
-        printf("\t\t\tinv[%d]\n", i);
 
     }
 
@@ -157,7 +149,6 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
     for (i = 0; i < (GFBITS * SYS_T + 7) / 8; i++) {
         for (j = 0; j < 8; j++) {
             row = i * 8 + j;
-            printf("\t\trow %d\n", row);
 
             if (row >= GFBITS * SYS_T) {
                 break;

--- a/software/firmware/MCELIECE/versat_pk_gen.cpp
+++ b/software/firmware/MCELIECE/versat_pk_gen.cpp
@@ -92,24 +92,29 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         buf[i] |= i;
     }
 
+    printf("\t\tsort\n");
     PQCLEAN_MCELIECE348864_CLEAN_sort_63b(1 << GFBITS, buf);
 
     for (i = 0; i < (1 << GFBITS); i++) {
         perm[i] = buf[i] & GFMASK;
     }
 
+    printf("\t\tbitrev\n");
     for (i = 0; i < SYS_N;         i++) {
         L[i] = PQCLEAN_MCELIECE348864_CLEAN_bitrev((gf)perm[i]);
     }
 
     // filling the matrix
 
+    printf("\t\troot\n");
     PQCLEAN_MCELIECE348864_CLEAN_root(inv, g, L);
 
+    printf("\t\tgf_inv\n");
     for (i = 0; i < SYS_N; i++) {
         inv[i] = PQCLEAN_MCELIECE348864_CLEAN_gf_inv(inv[i]);
     }
 
+    printf("\t\tmat = 0\n");
     for (i = 0; i < PK_NROWS; i++) {
         for (j = 0; j < SYS_N / 8; j++) {
             // mat[i][j] = 0;
@@ -117,6 +122,7 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         }
     }
 
+    printf("\t\tinv:\n");
     for (i = 0; i < SYS_T; i++) {
         for (j = 0; j < SYS_N; j += 8) {
             for (k = 0; k < GFBITS;  k++) {
@@ -143,6 +149,7 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
         for (j = 0; j < SYS_N; j++) {
             inv[j] = PQCLEAN_MCELIECE348864_CLEAN_gf_mul(inv[j], L[j]);
         }
+        printf("\t\t\tinv[%d]\n", i);
 
     }
 
@@ -150,6 +157,7 @@ int PQCLEAN_MCELIECE348864_CLEAN_pk_gen(uint8_t *pk, uint32_t *perm, const uint8
     for (i = 0; i < (GFBITS * SYS_T + 7) / 8; i++) {
         for (j = 0; j < 8; j++) {
             row = i * 8 + j;
+            printf("\t\trow %d\n", row);
 
             if (row >= GFBITS * SYS_T) {
                 break;


### PR DESCRIPTION
- update ETHERNET submodule
- fix linker script warnings for embedded software version
- reduce stack memory usage by implementing manual memory pool
- minor makefile fixes
- update CI jobs
- test McEliece in FPGA with:
```bash
# run test
make test-fpga ALGORITHM=MCELIECE
# clean
make test-fpga-clean ALGORITHM=MCELIECE
```